### PR TITLE
1. Codejam#1 2023Q1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# cssBayan
+# https://skit82.github.io/cssBayan/

--- a/css/style.css
+++ b/css/style.css
@@ -184,10 +184,22 @@ button,
   line-height: 2em;
   font-weight: 700;
   margin: 0;
-  border-bottom: 0.15em solid #000000;
+  border-bottom: 0.11em solid #000000;  
+}
+
+@media (min-width: 1024px) {
+  .accordion__title {
+    font-size: 2em;
+    line-height: 2.3em;
+    border-bottom: 0.15em solid #000000; 
+  }
 }
 
 .accordion__caption {
+  display: flex;
+  flex-direction: column;
+}
+.accordion__text {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -195,27 +207,29 @@ button,
   font-size: 0.7em;
   font-weight: 500px;
   line-height: 1.5em;
+  margin: 0;
   padding: 0.7em 0;
   cursor: pointer;
 }
 
+
 @media (min-width: 768px) {
-  .accordion__caption {
+  .accordion__text {
     font-size: 1.3em;
     line-height: 1.8em;
   }
 }
 
 @media (min-width: 1024px) {
-  .accordion__caption {
+  .accordion__text {
     font-size: 1.5em;
     line-height: 2em;
-    padding: 1.4em 0;
+    padding: 1.1em 0;
   }
 }
 
 @media (min-width: 1920px) {
-  .accordion__caption {
+  .accordion__text {
     font-size: 1.8em;
     line-height: 2.3em;
   }
@@ -228,14 +242,11 @@ button,
 .accordion__box {
   display: flex;
   flex-direction: column;
-  /*display: grid;*/
-  /*grid-template-columns: 1fr 1fr;*/
-  /*align-items: center;*/
-  /*padding: 0.7em 0;*/
+  -webkit-transition: -webkit-transform 0.3s ease-in-out;
+          transition: transform 0.3s ease-in-out;
 }
 
 .accordion__icon {
-  /*grid-column: min-content;*/
   display: inherit;
 }
 
@@ -246,33 +257,55 @@ button,
   margin-left: 10px;
   flex-shrink: 0;
   transform: rotate(0deg);
-  -webkit-transition: -webkit-transform 0.5s ease-in-out;
-          transition: transform 0.5s ease-in-out;
+  -webkit-transition: -webkit-transform 0.3s ease-in-out;
+          transition: transform 0.3s ease-in-out;
+}
+.accordion__description {
+  margin: 0;
 }
 
 .accordion__img {
   margin: 0 auto;
+  max-height: 0;
+  max-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: 2s;
   padding-bottom: 0.6em;
 }
 
-.accordion__description {
-  /*grid-column: 1/5;*/
-  display: none;
-  max-height: 0;
-  transition: max-height 0.3s;
-  overflow: hidden;
-  /*padding-bottom: 1.2em;*/
-  /*transition: all 0.4s ease-out;*/
-}
-
-.accordion__input:checked ~ .accordion__description {
-  display: block;
-  max-height: 100%;
-  transition: all 0.4s ease-out;
+.accordion__input:checked ~ .accordion__caption .accordion__img {
+  max-height: 100vh;
+  max-width: 100%;
+  opacity: 1;
 }
 
 .accordion__input:checked ~ .accordion__caption .accordion__icon svg {
   transform: rotate(180deg);
-  -webkit-transition: -webkit-transform 0.5s ease-in-out;
-          transition: transform 0.5s ease-in-out;
+  -webkit-transition: -webkit-transform 0.3s ease-in-out;
+          transition: transform 0.3s ease-in-out;
+}
+
+
+@media (hover: hover) {
+  .accordion__input:hover ~ .accordion__caption .accordion__img {
+    max-height: 100vh;
+    max-width: 100vh;
+    opacity: 1;
+  }
+}
+
+@media (hover: hover) {
+  .accordion__input:hover ~ .accordion__caption .accordion__icon svg {
+    transform: rotate(180deg);
+    color: red;
+    -webkit-transition: -webkit-transform 0.3s ease-in-out;
+          transition: transform 0.3s ease-in-out;
+  }
+}
+
+@media (hover: hover) {
+  .accordion:hover .accordion__text {
+    color: red;
+  }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -143,25 +143,28 @@ button,
 
 .container {
   width: 100%;
-  min-width: calc(100% - 5%);
+  max-width: calc(100% - 0%);
   margin: 0 auto;
   padding: 0 0.5em;
 }
 
 @media (min-width: 768px) {
   .container {
+    max-width: calc(100% - 0%);
     padding: 0 1.5em;
   }
 }
 
 @media (min-width: 1024px) {
   .container {
+    max-width: calc(100% - 15%);
     padding: 0 2em;
   }
 }
 
-@media (max-width: 1920px) {
+@media (min-width: 1920px) {
   .container {
+    max-width: calc(100% - 20%);
     padding: 0 2.5em;
   }
 }
@@ -180,5 +183,96 @@ button,
   font-size: 1.75em;
   line-height: 2em;
   font-weight: 700;
+  margin: 0;
+  border-bottom: 0.15em solid #000000;
+}
 
+.accordion__caption {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  /*grid-column: 1/-1;*/
+  font-size: 0.7em;
+  font-weight: 500px;
+  line-height: 1.5em;
+  padding: 0.7em 0;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .accordion__caption {
+    font-size: 1.3em;
+    line-height: 1.8em;
+  }
+}
+
+@media (min-width: 1024px) {
+  .accordion__caption {
+    font-size: 1.5em;
+    line-height: 2em;
+    padding: 1.4em 0;
+  }
+}
+
+@media (min-width: 1920px) {
+  .accordion__caption {
+    font-size: 1.8em;
+    line-height: 2.3em;
+  }
+}
+
+.accordion__item {
+  border-bottom: 0.1em solid #000000;
+}
+
+.accordion__box {
+  display: flex;
+  flex-direction: column;
+  /*display: grid;*/
+  /*grid-template-columns: 1fr 1fr;*/
+  /*align-items: center;*/
+  /*padding: 0.7em 0;*/
+}
+
+.accordion__icon {
+  /*grid-column: min-content;*/
+  display: inherit;
+}
+
+.accordion__icon svg {
+  fill: none;
+  width: 24px;
+  height: 24px;
+  margin-left: 10px;
+  flex-shrink: 0;
+  transform: rotate(0deg);
+  -webkit-transition: -webkit-transform 0.5s ease-in-out;
+          transition: transform 0.5s ease-in-out;
+}
+
+.accordion__img {
+  margin: 0 auto;
+  padding-bottom: 0.6em;
+}
+
+.accordion__description {
+  /*grid-column: 1/5;*/
+  display: none;
+  max-height: 0;
+  transition: max-height 0.3s;
+  overflow: hidden;
+  /*padding-bottom: 1.2em;*/
+  /*transition: all 0.4s ease-out;*/
+}
+
+.accordion__input:checked ~ .accordion__description {
+  display: block;
+  max-height: 100%;
+  transition: all 0.4s ease-out;
+}
+
+.accordion__input:checked ~ .accordion__caption .accordion__icon svg {
+  transform: rotate(180deg);
+  -webkit-transition: -webkit-transform 0.5s ease-in-out;
+          transition: transform 0.5s ease-in-out;
 }

--- a/index.html
+++ b/index.html
@@ -17,62 +17,70 @@
 			<div class="accordion__content">
 				<div class="accordion__item">
 					<div class="accordion__box">
-						<input class="accordion__input" type="radio" name="item1" id="number1" checked>
+						<input class="accordion__input" type="radio" name="item1" id="number1" hidden>
 						<label class="accordion__caption" for="number1">
-							two monkeys are fighting
-							<span class="accordion__icon">
-								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
-								</svg>
-							</span>	
+							<p class="accordion__text">
+								two monkeys are fighting
+								<span class="accordion__icon">
+									<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+									</svg>
+								</span>	
+							</p>
+							<p class="accordion__description">
+								<img class="accordion__img" src="img/img-desr1.jpg" width="300" height="223" alt="Картинка"/>
+							</p>
 						</label>
-						<div class="accordion__description">
-							<img class="accordion__img" src="img/img-desr1.jpg" width="300" height="223" alt="Картинка"/>
-						</div>
 					</div>
 				</div>
 				<div class="accordion__item">
 					<div class="accordion__box">
-						<input class="accordion__input" type="radio" name="item1" id="number2">
+						<input class="accordion__input" type="radio" name="item1" id="number2" hidden>
 						<label class="accordion__caption" for="number2">
-							who can I give money
-							<span class="accordion__icon">
-								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
-								</svg>
-							</span>
+							<p class="accordion__text">
+								who can I give money
+								<span class="accordion__icon">
+									<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+									</svg>
+								</span>
+							</p>
+							<p class="accordion__description">
+								<img class="accordion__img" src="img/img-descr2.jpg" width="500" height="465" alt="Картинка"/>
+							</p>
 						</label>
-						<div class="accordion__description">
-							<img class="accordion__img" src="img/img-descr2.jpg" width="500" height="465" alt="Картинка"/>
-						</div>
 					</div>	
 				</div>
 				<div class="accordion__item">
 					<div class="accordion__box">
-						<input class="accordion__input" type="radio" name="item1" id="number3">
+						<input class="accordion__input" type="radio" name="item1" id="number3" hidden>
 						<label class="accordion__caption" for="number3">
-							write unit tests or not
-							<span class="accordion__icon">
-								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+							<p class="accordion__text">
+								write unit tests or not
+								<span class="accordion__icon">
+									<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
 								</svg>
-							</span>
+								</span>
+							</p>
+							<p class="accordion__description">
+								<img class="accordion__img" src="img/img-descr3.jpg" width="300" height="224" alt="Картинка"/>
+							</p>
 						</label>
-						<div class="accordion__description">
-							<img class="accordion__img" src="img/img-descr3.jpg" width="300" height="224" alt="Картинка"/>
-						</div>
 					</div>	
 				</div>		
 				<div class="accordion__item">
 					<div class="accordion__box">
-						<input class="accordion__input" type="radio" name="item1" id="number4">
+						<input class="accordion__input" type="radio" name="item1" id="number4" checked>
 						<label class="accordion__caption" for="number4">
-							we work in a team
-							<span class="accordion__icon">
-								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
-								</svg>
-							</span>
+							<p class="accordion__text">
+								we work in a team
+								<span class="accordion__icon">
+									<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+									</svg>
+								</span>
+							</p>
+							<p class="accordion__description">
+								<img class="accordion__img" src="img/img-descr4.jpg" width="300" height="239" alt="Картинка"/>
+							</p>
 						</label>
-						<div class="accordion__description">
-							<img class="accordion__img" src="img/img-descr4.jpg" width="300" height="239" alt="Картинка"/>
-						</div>
 					</div>	
 				</div>				
 			</div>

--- a/index.html
+++ b/index.html
@@ -17,63 +17,63 @@
 			<div class="accordion__content">
 				<div class="accordion__item">
 					<div class="accordion__box">
+						<input class="accordion__input" type="radio" name="item1" id="number1" checked>
 						<label class="accordion__caption" for="number1">
 							two monkeys are fighting
+							<span class="accordion__icon">
+								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+								</svg>
+							</span>	
 						</label>
-						<input class="accordion__input" type="radio" name="item1" id="number1">
-						<span class="accordion__icon">
-							<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
-							</svg>
-						</span>	
-					</div>
-					<div class="accordion__description">
-						<img class="accordion__img" src="img/img-desr1.jpg" width="300" height="223" alt="Картинка"/>
+						<div class="accordion__description">
+							<img class="accordion__img" src="img/img-desr1.jpg" width="300" height="223" alt="Картинка"/>
+						</div>
 					</div>
 				</div>
 				<div class="accordion__item">
 					<div class="accordion__box">
-						<label class="accordion__caption" for="number2">
-							who can I give money to here?
-						</label>
 						<input class="accordion__input" type="radio" name="item1" id="number2">
-						<span class="accordion__icon">
-							<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
-							</svg>
-						</span>
+						<label class="accordion__caption" for="number2">
+							who can I give money
+							<span class="accordion__icon">
+								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+								</svg>
+							</span>
+						</label>
+						<div class="accordion__description">
+							<img class="accordion__img" src="img/img-descr2.jpg" width="500" height="465" alt="Картинка"/>
+						</div>
 					</div>	
-					<div class="accordion__description">
-						<img class="accordion__img" src="img/img-descr2.jpg" width="500" height="465" alt="Картинка"/>
-					</div>
 				</div>
 				<div class="accordion__item">
 					<div class="accordion__box">
-						<label class="accordion__caption" for="number2">
+						<input class="accordion__input" type="radio" name="item1" id="number3">
+						<label class="accordion__caption" for="number3">
 							write unit tests or not
+							<span class="accordion__icon">
+								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+								</svg>
+							</span>
 						</label>
-						<input class="accordion__input" type="radio" name="item1" id="number2">
-						<span class="accordion__icon">
-							<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
-							</svg>
-						</span>
+						<div class="accordion__description">
+							<img class="accordion__img" src="img/img-descr3.jpg" width="300" height="224" alt="Картинка"/>
+						</div>
 					</div>	
-					<div class="accordion__description">
-						<img class="accordion__img" src="img/img-descr3.jpg" width="300" height="224" alt="Картинка"/>
-					</div>
 				</div>		
 				<div class="accordion__item">
 					<div class="accordion__box">
-						<label class="accordion__caption" for="number2">
-							we work in a team guys
+						<input class="accordion__input" type="radio" name="item1" id="number4">
+						<label class="accordion__caption" for="number4">
+							we work in a team
+							<span class="accordion__icon">
+								<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
+								</svg>
+							</span>
 						</label>
-						<input class="accordion__input" type="radio" name="item1" id="number2">
-						<span class="accordion__icon">
-							<svg width="16" height="9" viewBox="0 0 16 9" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path d="M14 2L8 8L2 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="bevel"/>
-							</svg>
-						</span>
+						<div class="accordion__description">
+							<img class="accordion__img" src="img/img-descr4.jpg" width="300" height="239" alt="Картинка"/>
+						</div>
 					</div>	
-					<div class="accordion__description">
-						<img class="accordion__img" src="img/img-descr4.jpg" width="300" height="239" alt="Картинка"/>
-					</div>
 				</div>				
 			</div>
 		</div>


### PR DESCRIPTION
1. Task: https://github.com/DrDiman/CSS-Bayan-task
2. 
![cssBayan](https://user-images.githubusercontent.com/18705925/224573539-48f3959e-9817-4661-8521-fff6530b9344.jpg)
3. https://skit82.github.io/cssBayan/index.html
4. Done 00:07 13.03.2023 / Deadline 02:59 13.03.2023
5. 140/140
[+]Everything is done from Repository requirements and how to submit task section +30
[+]The accordion component is centered on the screen, with equal indents on the left and right +10
[+]Icons, meme texts and meme images are exist +5
[+]Placement of the meme, icons and meme text are the same as in provided example gif images +5
[+]Smooth change (transition) of the meme images and icons is done +20
[+]Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 320x568, tablet 820x1180, desktop 1920×1080. (Note: breakpoints don't have to be 320x568, 820x1180, 1920x1080). +10
[+]All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is selected are implemented +10
[+]The entire row (text, icon, and meme image) clickable +5
[+]Cursor over the memes (hover) effect only exists for devices that can support hover. +10
[+]The cursor when it is hovering over the rows of the accordion is changing +5
[+]Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive +10
[+]All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static +5
[+]Pseudo-elements are not used (note 1: pseudo-classes are allowed; note 2: pseudo-elements only from FontAwesome are allowed) +5
[+]Initially, the first meme should be expanded +5
[+]Font size is changed at each device (mobile, tablet, desktop) +5